### PR TITLE
Fix widget

### DIFF
--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets_extended.dropdown import DropdownExtended"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a63cac5b89fe48bf871adc87c46462da",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DropdownExtended(disabled_options=['Option 1', 'Option 3', 'Option 4'], index=1, layout=Layout(width='auto'), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "DropdownExtended(\n",
+    "    options=[\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"],\n",
+    "    disabled_options=[\"Option 1\", \"Option 3\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the example above, **DropdownExtended** is initialized with 4 option, 2 of which are disabled.\n",
+    "Note that since the first option is disabled, the widget initializes with the first non-disabled option - in this case _Option 2_.\n",
+    "\n",
+    "If all options are initialized as disabled, the widget will mimic the **Dropdown** widget, if no options had been supplied, i.e., it will set `index`, `label`, and `value` to `None`, leaving the \"chosen\" option blank:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fdfdfd45913f44bb9eb3dd52ff6368be",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DropdownExtended(disabled_options=['Option 1', 'Option 2', 'Option 3', 'Option 4'], options=('Option 1', 'Opti…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "DropdownExtended(\n",
+    "    options=[\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"],\n",
+    "    disabled_options=[\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"],\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ipywidgets_extended/dropdown.py
+++ b/ipywidgets_extended/dropdown.py
@@ -1,7 +1,7 @@
 """Dropdown Widget Extension"""
 from typing import List
 
-from ipywidgets.widgets.widget_selection import Dropdown
+from ipywidgets.widgets.widget_selection import Dropdown, _make_options
 from traitlets import traitlets
 
 from ipywidgets_extended.version import __version__
@@ -26,6 +26,28 @@ class DropdownExtended(Dropdown):
     _view_module_version = traitlets.Unicode(__version__).tag(sync=True)
 
     disabled_options = traitlets.List([]).tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        options = _make_options(kwargs.get("options", ()))
+
+        # Ensure initialized 'index' is an enabled option (if possible)
+        if (
+            "index" not in kwargs
+            and "value" not in kwargs
+            and "label" not in kwargs
+            and "disabled_options" in kwargs
+        ):
+            for index, option in enumerate(options):
+                if option[0] not in kwargs["disabled_options"]:
+                    kwargs["index"] = index
+                    kwargs["label"], kwargs["value"] = options[index]
+                    break
+            else:
+                if options:
+                    kwargs["index"] = kwargs["label"] = kwargs["value"] = None
+
+        super().__init__(*args, **kwargs)
+        self._initializing_traits_ = False
 
     @traitlets.validate("disabled_options")
     def _validate_disabled_options(self, proposal: dict) -> List[str]:

--- a/ipywidgets_extended/dropdown.py
+++ b/ipywidgets_extended/dropdown.py
@@ -1,7 +1,6 @@
 """Dropdown Widget Extension"""
 from typing import List
 
-from ipywidgets._version import __jupyter_widgets_controls_version__
 from ipywidgets.widgets.widget_selection import Dropdown
 from traitlets import traitlets
 
@@ -19,13 +18,11 @@ class DropdownExtended(Dropdown):
 
     """
 
-    _model_name = traitlets.Unicode("DropdownModel").tag(sync=True)
-    _model_module = traitlets.Unicode("@jupyter-widgets/controls").tag(sync=True)
-    _model_module_version = traitlets.Unicode(__jupyter_widgets_controls_version__).tag(
-        sync=True
-    )
+    _model_name = traitlets.Unicode("DropdownExtendedModel").tag(sync=True)
+    _model_module = traitlets.Unicode("ipywidgets-extended").tag(sync=True)
+    _model_module_version = traitlets.Unicode(__version__).tag(sync=True)
     _view_name = traitlets.Unicode("DropdownExtendedView").tag(sync=True)
-    _view_module = traitlets.Unicode("optimade-client").tag(sync=True)
+    _view_module = traitlets.Unicode("ipywidgets-extended").tag(sync=True)
     _view_module_version = traitlets.Unicode(__version__).tag(sync=True)
 
     disabled_options = traitlets.List([]).tag(sync=True)


### PR DESCRIPTION
Update metadata information in the Python part of the `DropdownExtended` widget.

Ensure the starting value for the `DropdownExtended` widget is as expected:
- Choosing the first enabled option.
- If there are no enabled options, do the same as if there was no options at all (empty, setting `index`, `label`, and `value` to `None`).

Add example notebook to showcase `DropdownExtended` widget.