### PR TITLE
Ensure widget is updated when disabling options

### DIFF
--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,24 +11,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a63cac5b89fe48bf871adc87c46462da",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DropdownExtended(disabled_options=['Option 1', 'Option 3', 'Option 4'], index=1, layout=Layout(width='auto'), …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "DropdownExtended(\n",
     "    options=[\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"],\n",
@@ -40,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the example above, **DropdownExtended** is initialized with 4 option, 2 of which are disabled.\n",
+    "In the example above, **DropdownExtended** is initialized with 4 options, 2 of which are disabled.\n",
     "Note that since the first option is disabled, the widget initializes with the first non-disabled option - in this case _Option 2_.\n",
     "\n",
     "If all options are initialized as disabled, the widget will mimic the **Dropdown** widget, if no options had been supplied, i.e., it will set `index`, `label`, and `value` to `None`, leaving the \"chosen\" option blank:"
@@ -48,29 +33,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fdfdfd45913f44bb9eb3dd52ff6368be",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DropdownExtended(disabled_options=['Option 1', 'Option 2', 'Option 3', 'Option 4'], options=('Option 1', 'Opti…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "DropdownExtended(\n",
     "    options=[\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"],\n",
     "    disabled_options=[\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"],\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown = DropdownExtended(\n",
+    "    options=[\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"]\n",
+    ")\n",
+    "dropdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown.disabled_options = [\"Option 2\", \"Option 3\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the dropdown above, it is first rendered without any disabled options (try running only the first cell to see).\n",
+    "\n",
+    "When the second cell is run the options `Option 2` and `Option 3` are disabled.\n",
+    "Depending on which value you have currently chosen, the dropbox will do different things:\n",
+    "\n",
+    "- If you prior to running the second cell have chosen a value that is still enabled afterwards, it will stay the chosen value (try this out by choosing `Option 4`).\n",
+    "- If you prior to running the second cell have chosen a value that is disabled afterwards, the widget will default to the first value (from the beginning/top) that is enabled.\n",
+    "  If no values are enabled, you will get the same result as the second **DropdownExtended** widget above (no value will be chosen, leaving it blank and the `value` will be `None`).\n",
+    "  You can try this out by first choosing `Option 2` or `Option 3` and then running the second cell.\n",
+    "  This will result in `Option 1` being chosen.\n",
+    "  And if you extend the list of disabled options in the second cell to include also `Option 1` and `Option 4`, you will see that this will leave the widget blank (you can run the cell below to try this out)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown.disabled_options = [\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"]"
    ]
   }
  ],

--- a/ipywidgets_extended/dropdown.py
+++ b/ipywidgets_extended/dropdown.py
@@ -25,10 +25,21 @@ class DropdownExtended(Dropdown):
     _view_module = traitlets.Unicode("ipywidgets-extended").tag(sync=True)
     _view_module_version = traitlets.Unicode(__version__).tag(sync=True)
 
+    # This being read-only means that it cannot be changed by the user.
+    _disabled_options_labels = traitlets.List(
+        trait=traitlets.Unicode(),
+        read_only=True,
+        help="The labels for the disabled options.",
+    ).tag(sync=True)
+
     disabled_options = traitlets.List([]).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
+        self._initializing_traits_ = True
+
         options = _make_options(kwargs.get("options", ()))
+        disabled_options = kwargs.get("disabled_options", [])
+        self.set_trait("_disabled_options_labels", disabled_options)
 
         # Ensure initialized 'index' is an enabled option (if possible)
         if (
@@ -38,24 +49,45 @@ class DropdownExtended(Dropdown):
             and "disabled_options" in kwargs
         ):
             for index, option in enumerate(options):
-                if option[0] not in kwargs["disabled_options"]:
+                if option[0] not in disabled_options:
                     kwargs["index"] = index
                     kwargs["label"], kwargs["value"] = options[index]
                     break
             else:
-                if options:
-                    kwargs["index"] = kwargs["label"] = kwargs["value"] = None
+                kwargs["index"] = kwargs["label"] = kwargs["value"] = None
 
         super().__init__(*args, **kwargs)
         self._initializing_traits_ = False
 
     @traitlets.validate("disabled_options")
-    def _validate_disabled_options(self, proposal: dict) -> List[str]:
+    def _validate_disabled_options(self, proposal) -> List[str]:
         """Ensure disabled_options values are part of the list of options"""
-        if proposal.value is None:
+        if proposal.value is None or not proposal.value:
             return []
         proposal_diff = set(proposal.value).difference_update(set(self._options_labels))
         assert (
             not proposal_diff
         ), f"Invalid passed options for 'disabled_options': {proposal_diff}"
         return proposal.value
+
+    @traitlets.observe("disabled_options")
+    def _set_disabled_options(self, change) -> None:
+        """Ensure the widget is updated properly."""
+        disabled_options = change.new
+        self.set_trait("_disabled_options_labels", disabled_options)
+        if not self._initializing_traits_:
+            if disabled_options:
+                if self._options_labels[self.index] in disabled_options:
+                    for index, label in enumerate(self._options_labels):
+                        if label not in disabled_options:
+                            self.index = index
+                            break
+                    else:
+                        self.index = None
+            elif self._options_labels:
+                if self.index == 0:
+                    self._notify_trait("index", 0, 0)
+                else:
+                    self.index = 0
+            else:
+                self.index = None

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,4 +1,4 @@
-import { ISerializers } from '@jupyter-widgets/base';
+import { ISerializers, WidgetView } from '@jupyter-widgets/base';
 import { DropdownModel, DropdownView } from '@jupyter-widgets/controls';
 
 import { MODULE_NAME, MODULE_VERSION } from './version';
@@ -29,10 +29,15 @@ class DropdownExtendedModel extends DropdownModel {
 
 export
 class DropdownExtendedView extends DropdownView {
+    initialize(parameters: WidgetView.InitializeParameters): void {
+        super.initialize(parameters);
+        this.listenTo(this.model, 'change:_disabled_options_labels', () => this._updateOptions());
+    }
+
     _updateOptions(): void {
         this.listbox.textContent = '';
         const items = this.model.get('_options_labels');
-        const disabled_items = this.model.get('disabled_options');
+        const disabled_items = this.model.get('_disabled_options_labels');
         for (let i = 0; i < items.length; i++) {
             const item = items[i];
             const option = document.createElement('option');


### PR DESCRIPTION
Certain choices have been made regarding fallback index choices
depending on the currently chosen index upon editing the disabled
options.
See `example.ipynb` for an explanation.

Fixes #3.