### PR TITLE
Publish bdist_wheel alongside sdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       run: |
         ORIGINAL_PWD=$(pwd)
 
-        if [ "${ORIGINAL_PWD}" == "/tmp/installation_dir" ]; then; echo "Wrong original dir: ${ORIGINAL_PWD}"; exit 1; fi
+        if [ "${ORIGINAL_PWD}" == "/tmp/installation_dir" ]; then echo "Wrong original dir: ${ORIGINAL_PWD}"; exit 1; fi
         mkdir -p /tmp/installation_dir
         cd /tmp/installation_dir
         pip install ${ORIGINAL_PWD}/${BDIST_DIR}/${{ env.BDIST_FILE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         python setup.py -v sdist -d ${SDIST_DIR} bdist_wheel -d ${BDIST_DIR}
         SDIST_FILE=$( ls ${SDIST_DIR}/ )
         echo "BDIST_FILE=$( ls ${BDIST_DIR}/ )" >> $GITHUB_ENV
-        echo "ORIGINAL_PWD=$(pwd)"" >> $GITHUB_ENV
+        echo "ORIGINAL_PWD=$(pwd)" >> $GITHUB_ENV
 
         mkdir -p /tmp/installation_dir
         cd /tmp/installation_dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python requirements
-      run: pip install -r requirements.txt
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install -r requirements.txt
 
     - name: Check build and installation of PyPI source distribution
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
         python setup.py -v sdist -d ${SDIST_DIR} bdist_wheel -d ${BDIST_DIR}
         SDIST_FILE=$( ls ${SDIST_DIR}/ )
         echo "BDIST_FILE=$( ls ${BDIST_DIR}/ )" >> $GITHUB_ENV
-        echo "ORIGINAL_PWD=$(pwd)" >> $GITHUB_ENV
+        ORIGINAL_PWD=$(pwd)
 
         mkdir -p /tmp/installation_dir
         cd /tmp/installation_dir
-        pip install ${{ env.ORIGINAL_PWD }}/${SDIST_DIR}/${SDIST_FILE}
+        pip install ${ORIGINAL_PWD}/${SDIST_DIR}/${SDIST_FILE}
 
     - name: Assert nbextension installed correctly
       run: ./.github/static/check_nbextensions.py
@@ -97,9 +97,12 @@ jobs:
       env:
         BDIST_DIR: bdist_action
       run: |
+        ORIGINAL_PWD=$(pwd)
+
+        if [ "${ORIGINAL_PWD}" == "/tmp/installation_dir" ]; then; echo "Wrong original dir: ${ORIGINAL_PWD}"; exit 1; fi
         mkdir -p /tmp/installation_dir
         cd /tmp/installation_dir
-        pip install ${{ env.ORIGINAL_PWD }}/${BDIST_DIR}/${{ env.BDIST_FILE }}
+        pip install ${ORIGINAL_PWD}/${BDIST_DIR}/${{ env.BDIST_FILE }}
 
     - name: Assert nbextension installed correctly
       run: ./.github/static/check_nbextensions.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,16 @@ jobs:
     - name: Assert nbextension installed correctly
       run: ./.github/static/check_nbextensions.py
 
+    - name: Remove installation again
+      run: pip uninstall -y ipywidgets-extended
+
+    - name: Ensure it was removed as an nbextension
+      run: ./.github/static/check_nbextensions.py && exit 1 || ( echo "Failed as expected" ; exit 0 )
+
     - name: Re-install wheel
       env:
         BDIST_DIR: bdist_action
       run: |
-        pip uninstall -y ipywidgets-extended
-
         mkdir -p /tmp/installation_dir
         cd /tmp/installation_dir
         pip install ${{ env.ORIGINAL_PWD }}/${BDIST_DIR}/${{ env.BDIST_FILE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,29 @@ jobs:
     - name: Check build and installation of PyPI source distribution
       env:
         SDIST_DIR: sdist_action
+        BDIST_DIR: bdist_action
       run: |
-        python setup.py -v sdist -d ${SDIST_DIR}
+        python setup.py -v sdist -d ${SDIST_DIR} bdist_wheel -d ${BDIST_DIR}
         SDIST_FILE=$( ls ${SDIST_DIR}/ )
-        ORIGINAL_PWD=$(pwd)
+        echo "BDIST_FILE=$( ls ${BDIST_DIR}/ )" >> $GITHUB_ENV
+        echo "ORIGINAL_PWD=$(pwd)"" >> $GITHUB_ENV
 
         mkdir -p /tmp/installation_dir
         cd /tmp/installation_dir
-        pip install ${ORIGINAL_PWD}/${SDIST_DIR}/${SDIST_FILE}
+        pip install ${{ env.ORIGINAL_PWD }}/${SDIST_DIR}/${SDIST_FILE}
+
+    - name: Assert nbextension installed correctly
+      run: ./.github/static/check_nbextensions.py
+
+    - name: Re-install wheel
+      env:
+        BDIST_DIR: bdist_action
+      run: |
+        pip uninstall -y ipywidgets-extended
+
+        mkdir -p /tmp/installation_dir
+        cd /tmp/installation_dir
+        pip install ${{ env.ORIGINAL_PWD }}/${BDIST_DIR}/${{ env.BDIST_FILE }}
 
     - name: Assert nbextension installed correctly
       run: ./.github/static/check_nbextensions.py

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Update setuptools and install requirements
       run: |
         python -m pip install --upgrade pip
-        pip install -U setuptools
+        pip install -U setuptools wheel
         pip install -r requirements.txt
 
     - name: Update version and tag

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.repository == 'CasperWA/ipywidgets-extended' && startsWith(github.ref, 'refs/tags/v')
     env:
       PUBLISH_UPDATE_BRANCH: main
+      PY_DIST_DIR: py_dist
 
     steps:
     - name: Checkout repository
@@ -44,7 +45,7 @@ jobs:
         tags: true
 
     - name: Build source distribution
-      run: python setup.py -v sdist -d py_dist
+      run: python setup.py -v sdist -d ${{ env.PY_DIST_DIR }} bdist_wheel -d ${{ env.PY_DIST_DIR }}
 
     - name: Publish package to TestPyPI
       uses: pypa/gh-action-pypi-publish@master
@@ -52,11 +53,11 @@ jobs:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
-        packages_dir: py_dist/
+        packages_dir: ${{ env.PY_DIST_DIR }}/
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
-        packages_dir: py_dist/
+        packages_dir: ${{ env.PY_DIST_DIR }}/


### PR DESCRIPTION
Due to the requirement of Node and NPM when building the wheel from the source distribution, the wheel should be included when published.

This PR adds a CI check for `bdist_wheel`.