### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set PY env var
       run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v2.1.4
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -55,7 +55,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Node 13
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v2
       with:
         node-version: '13'
 

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Node 13
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
       with:
         node-version: '13'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
+  rev: v3.4.0
   hooks:
   - id: check-yaml
   - id: check-json
@@ -14,7 +14,7 @@ repos:
     name: Blacken
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.8.4'
+  rev: '3.9.0'
   hooks:
   - id: flake8
     args: [--count, --show-source, --statistics]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ipywidgets~=7.5
+ipywidgets~=7.6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
-invoke~=1.4
+invoke~=1.5
 pre-commit~=2.11
 pylint~=2.7

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 invoke~=1.4
-pre-commit~=2.8
-pylint~=2.6
+pre-commit~=2.11
+pylint~=2.7


### PR DESCRIPTION
Update Python dependencies and GH Actions according to @dependabot.

Use latest major version for `actions/setup-node` instead of the fully specified version.

Update pre-commit hooks.