### PR TITLE
Add grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,24 @@ The intent is to not produce completely new widgets, but rather _extend_ the wid
 
 ### Dropdown
 
-The dropdown widget has been extended to include the possibility of disabling options.
+The dropdown widget has been extended to include the possibility of:
 
-This can be done _via_ the `disabled_options` traitlet, which must be a list of option labels.
+- disabling options; and
+- grouping the options.
+
+#### Disabling
+
+This can be done *via* the `disabled_options` traitlet, which must be a list of option labels.
 If an option label is included in the `disabled_options` list traitlet, it will be "grayed out", i.e., disabled (but still visible) in the dropdown widget.
+
+#### Grouping
+
+Using the `grouping` parameter *instead of* the `options` parameter, options can be grouped as desired.
+The format is similar to the value for `options`, but each grouping of options should be paired with a header, i.e., you'll the value to be an iterable of (header, `options`)-pairs.
+
+One can introduce un-grouped options by passing an empty header, i.e., an empty string (`""`).
+
+## About
 
 **Author**: Casper Welzel Andersen ([email](casper+github@welzel.nu), [website](https://casper.welzel.nu)).  
 **License**: [BSD-3-Clause](LICENSE) and copyright (c) 2020 Casper Welzel Andersen & parts by Jupyter Development Team.

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -10,6 +10,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `DropdownExtended` widget\n",
+    "\n",
+    "## Disabled options"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -94,7 +103,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Grouping\n",
+    "## Grouping\n",
     "\n",
     "The options can be grouped as well using the `grouping` parameter.\n",
     "Note, `grouping` is an *alternative* to using `options` when initializing, using both will result in a `ValueError`.\n",
@@ -131,11 +140,37 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Disabled options\n",
+    "\n",
+    "Grouping can be combined with disabled options as well.\n",
+    "In the following a new dropdown has some disabled options:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "dropdown = DropdownExtended(\n",
+    "    grouping=[\n",
+    "        (\"Group 1\", [(\"Option 1-1\", \"Value 1-1\"), (\"Option 1-2\", \"Value 1-2\")]),\n",
+    "        (\"Group 2\", [(\"Option 2-1\", \"Value 2-1\"), (\"Option 2-2\", \"Value 2-2\"), (\"Option 2-3\", \"Value 2-3\")]),\n",
+    "    ],\n",
+    "    disabled_options=[\"Option 2-3\", \"Option 1-1\"],\n",
+    ")\n",
+    "dropdown"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The disabled options can be changed here as well."
+   ]
   }
  ],
  "metadata": {

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -171,6 +171,62 @@
    "source": [
     "The disabled options can be changed here as well."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown.disabled_options = [\"Option 1-1\", \"Option 1-2\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Mixed grouped and un-grouped options\n",
+    "\n",
+    "One can create un-grouped options alongside grouped options by setting the header to an empty string `\"\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown = DropdownExtended(\n",
+    "    grouping=[\n",
+    "        (\"\", [\"Choose an option ...\"]),\n",
+    "        (\"Group 1\", [(\"Option 1-1\", \"Value 1-1\"), (\"Option 1-2\", \"Value 1-2\")]),\n",
+    "        (\"\", [(\"This option is not grouped\", \"Non-grouped value 1\"), (\"This second option is not grouped\", \"Non-grouped value 2\")]),\n",
+    "        (\"Group 2\", [(\"Option 2-1\", \"Value 2-1\"), (\"Option 2-2\", \"Value 2-2\"), (\"Option 2-3\", \"Value 2-3\")]),\n",
+    "    ]\n",
+    ")\n",
+    "dropdown"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The grouping can also be updated after creating the object.\n",
+    "Let's remove the un-grouped options between the groups and only have a single option in `\"Group 1\"`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown.grouping = [\n",
+    "    (\"\", [\"Choose an option ...\"]),\n",
+    "    (\"Group 1\", [(\"Option 1-1\", \"Value 1-1\")]),\n",
+    "    (\"Group 2\", [(\"Option 2-1\", \"Value 2-1\"), (\"Option 2-2\", \"Value 2-2\"), (\"Option 2-3\", \"Value 2-3\")]),\n",
+    "]"
+   ]
   }
  ],
  "metadata": {

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -89,6 +89,13 @@
    "source": [
     "dropdown.disabled_options = [\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"]"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -91,6 +91,46 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Grouping\n",
+    "\n",
+    "The options can be grouped as well using the `grouping` parameter.\n",
+    "Note, `grouping` is an *alternative* to using `options` when initializing, using both will result in a `ValueError`.\n",
+    "\n",
+    "The value for `grouping` should be an iterable of (header, `options`)-pairs, where `options` signifies a value similar to what you would normally put for the `options` parameter.\n",
+    "Example:\n",
+    "\n",
+    "```python\n",
+    "grouping = [\n",
+    "    (\n",
+    "        \"Group 1\",\n",
+    "        [(\"Option 1-1\", \"Value 1-1\"), (\"Option 1-2\", \"Value 1-2\")]\n",
+    "    ),\n",
+    "    (\n",
+    "        \"Group 2\",\n",
+    "        [(\"Option 2-1\", \"Value 2-1\"), (\"Option 2-2\", \"Value 2-2\"), (\"Option 2-3\", \"Value 2-3\")]\n",
+    "    )\n",
+    "]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DropdownExtended(\n",
+    "    grouping=[\n",
+    "        (\"Group 1\", [(\"Option 1-1\", \"Value 1-1\"), (\"Option 1-2\", \"Value 1-2\")]),\n",
+    "        (\"Group 2\", [(\"Option 2-1\", \"Value 2-1\"), (\"Option 2-2\", \"Value 2-2\"), (\"Option 2-3\", \"Value 2-3\")]),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/ipywidgets_extended/dropdown.py
+++ b/ipywidgets_extended/dropdown.py
@@ -1,5 +1,5 @@
 """Dropdown Widget Extension"""
-from typing import List
+from typing import List, Tuple
 
 from ipywidgets.widgets.widget_selection import Dropdown, _make_options
 from traitlets import traitlets
@@ -15,6 +15,7 @@ class DropdownExtended(Dropdown):
 
     Extensions:
     - Disable individual options.
+    - Create groupings within the dropdown.
 
     """
 
@@ -25,14 +26,30 @@ class DropdownExtended(Dropdown):
     _view_module = traitlets.Unicode("ipywidgets-extended").tag(sync=True)
     _view_module_version = traitlets.Unicode(f"^{__version__}").tag(sync=True)
 
-    # This being read-only means that it cannot be changed by the user.
+    # Additional widget properties used in the TS
     _disabled_options_labels = traitlets.List(
         trait=traitlets.Unicode(),
         read_only=True,
         help="The labels for the disabled options.",
     ).tag(sync=True)
+    _grouping_labels = traitlets.List(
+        traitlets.Tuple(traitlets.Unicode(), traitlets.List(traitlets.Unicode())),
+        read_only=True,
+        help=(
+            "List of tuples for groupings, where the first value in the tuple is the grouping "
+            "header and the second value is a list of the labels in the grouping."
+        ),
+    ).tag(sync=True)
 
-    disabled_options = traitlets.List([]).tag(sync=True)
+    # The equivalent Python changeable traits
+    disabled_options = traitlets.List(traitlets.Unicode(), default_value=[])
+    grouping = traitlets.List(
+        traitlets.Tuple(
+            traitlets.Unicode(),
+            traitlets.List(traitlets.Unicode()),
+        ),
+        default_value=[],
+    )
 
     def __init__(self, *args, **kwargs):
         self._initializing_traits_ = True
@@ -77,6 +94,9 @@ class DropdownExtended(Dropdown):
         self.set_trait("_disabled_options_labels", disabled_options)
         if not self._initializing_traits_:
             if disabled_options:
+                grouping_entries = range(
+                    sum(len(_) + 1 for _ in dict(self._grouping_labels).values())
+                )
                 if self._options_labels[self.index] in disabled_options:
                     for index, label in enumerate(self._options_labels):
                         if label not in disabled_options:
@@ -84,10 +104,49 @@ class DropdownExtended(Dropdown):
                             break
                     else:
                         self.index = None
-            elif self._options_labels:
+                elif grouping_entries[self.index] in disabled_options:
+                    for index, label in enumerate(grouping_entries):
+                        if (
+                            label not in disabled_options
+                            and label not in self._group_headers
+                        ):
+                            self.index = index
+                            break
+                    else:
+                        self.index = None
+            elif self._options_labels and not self._grouping_labels:
                 if self.index == 0:
                     self._notify_trait("index", 0, 0)
                 else:
                     self.index = 0
             else:
                 self.index = None
+
+    @traitlets.validate("grouping")
+    def _validate_grouping(self, proposal) -> List[Tuple[str, List[str]]]:
+        """Ensure all group headers are unique"""
+        if proposal.value is None or not proposal.value:
+            return []
+        assert len(proposal.value) == len(
+            dict(proposal.value).keys()
+        ), f"Group headers must be unique. Passed group headers: {[_[0] for _ in proposal.value]}"
+        return proposal.value
+
+    @traitlets.observe("grouping")
+    def _set_grouping(self, change) -> None:
+        """Put options into desired grouping, updating `options`"""
+        grouping = change.new
+        self.set_trait("_grouping_labels", grouping)
+        if not self._initializing_traits_:
+            if not grouping and self._options_labels:
+                if self.index == 0:
+                    self._notify_trait("index", 0, 0)
+                else:
+                    self.index = 0
+            else:
+                self.index = None
+
+    @property
+    def _group_headers(self) -> List[str]:
+        """Get group headers from self._grouping_labels"""
+        return [_[0] for _ in self._grouping_labels]

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -43,9 +43,10 @@ class DropdownExtendedView extends DropdownView {
         if (grouping && grouping.length) {
             for (let i = 0; i < grouping.length; i++) {
                 const header = grouping[i][0];
-                this._updateOptionsUtility(header, true, true);
+                if (header) { this._updateOptionsUtility(header, true, true); }
                 for (let j = 0; j < grouping[i][1].length; j++) {
-                    const item = ' ' + grouping[i][1][j];
+                    let item = grouping[i][1][j];
+                    if (header) { item = ' ' + item; }
                     const disabled = disabled_items.includes(grouping[i][1][j]);
                     this._updateOptionsUtility(item, disabled, false);
                 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -45,8 +45,8 @@ class DropdownExtendedView extends DropdownView {
                 const header = grouping[i][0];
                 this._updateOptionsUtility(header, true, true);
                 for (let j = 0; j < grouping[i][1].length; j++) {
-                    const item = '\xa0' + grouping[i][j];
-                    const disabled = disabled_items.includes(grouping[i][j]);
+                    const item = ' ' + grouping[i][1][j];
+                    const disabled = disabled_items.includes(grouping[i][1][j]);
                     this._updateOptionsUtility(item, disabled, false);
                 }
             }
@@ -59,11 +59,12 @@ class DropdownExtendedView extends DropdownView {
         }
     }
 
-    _updateOptionsUtility(item: string, disabled: boolean, bold: boolean): void {
+    _updateOptionsUtility(item: string, disabled: boolean, bold_and_black: boolean): void {
         const option = document.createElement('option');
         option.textContent = item.replace(/ /g, '\xa0'); // space -> &nbsp; (no-break space)
-        if (bold) {
+        if (bold_and_black) {
             option.style.fontWeight = 'bold';
+            option.style.color = 'black';
         }
         option.setAttribute('data-value', encodeURIComponent(item));
         option.disabled = disabled;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -32,20 +32,42 @@ class DropdownExtendedView extends DropdownView {
     initialize(parameters: WidgetView.InitializeParameters): void {
         super.initialize(parameters);
         this.listenTo(this.model, 'change:_disabled_options_labels', () => this._updateOptions());
+        this.listenTo(this.model, 'change:_grouping_labels', () => this._updateOptions());
     }
 
     _updateOptions(): void {
         this.listbox.textContent = '';
+        const grouping = this.model.get('_grouping_labels');
         const items = this.model.get('_options_labels');
         const disabled_items = this.model.get('_disabled_options_labels');
-        for (let i = 0; i < items.length; i++) {
-            const item = items[i];
-            const option = document.createElement('option');
-            option.textContent = item.replace(/ /g, '\xa0'); // space -> &nbsp;
-            option.setAttribute('data-value', encodeURIComponent(item));
-            option.disabled = disabled_items.includes(item);
-            option.value = item;
-            this.listbox.appendChild(option);
+        if (grouping && grouping.length) {
+            for (let i = 0; i < grouping.length; i++) {
+                const header = grouping[i][0];
+                this._updateOptionsUtility(header, true, true);
+                for (let j = 0; j < grouping[i][1].length; j++) {
+                    const item = '\xa0' + grouping[i][j];
+                    const disabled = disabled_items.includes(grouping[i][j]);
+                    this._updateOptionsUtility(item, disabled, false);
+                }
+            }
+        } else {
+            for (let i = 0; i < items.length; i++) {
+                const item = items[i];
+                const disabled = disabled_items.includes(item);
+                this._updateOptionsUtility(item, disabled, false);
+            }
         }
+    }
+
+    _updateOptionsUtility(item: string, disabled: boolean, bold: boolean): void {
+        const option = document.createElement('option');
+        option.textContent = item.replace(/ /g, '\xa0'); // space -> &nbsp; (no-break space)
+        if (bold) {
+            option.style.fontWeight = 'bold';
+        }
+        option.setAttribute('data-value', encodeURIComponent(item));
+        option.disabled = disabled;
+        option.value = item;
+        this.listbox.appendChild(option);
     }
 }


### PR DESCRIPTION
Closes #8.

The new `grouping` can be set to create bold headers and slightly indented values within in the `DropdownExtended` widget.
The headers are automatically disabled, and cannot be used as a valid option.

One can add un-grouped options alongside the groups by using an empty header, i.e., an empty string (`""`).

The grouping feature works together with the disabling options feature.