### PR TITLE
Update dependencies & GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version}}
 
@@ -33,7 +33,7 @@ jobs:
     - name: Set PY env var
       run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
-    - uses: actions/cache@v2.1.6
+    - uses: actions/cache@v2
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -52,15 +52,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
 
     - name: Install Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v2.4.1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
 
     - name: Install Node 13
-      uses: actions/setup-node@v2.4.1
+      uses: actions/setup-node@v2
       with:
         node-version: '13'
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: 3.9
 
@@ -37,7 +37,7 @@ jobs:
       run: .github/static/update_version.sh
 
     - name: Push updates to '${{ env.PUBLISH_UPDATE_BRANCH }}'
-      uses: CasperWA/push-protected@v2.4.0
+      uses: CasperWA/push-protected@v2
       with:
         token: ${{ secrets.RELEASE_PAT }}
         branch: ${{ env.PUBLISH_UPDATE_BRANCH }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     exclude: README.md
 
 - repo: https://github.com/ambv/black
-  rev: 21.7b0
+  rev: 21.9b0
   hooks:
   - id: black
     name: Blacken

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 invoke~=1.6
-pre-commit~=2.14
-pylint~=2.10
+pre-commit~=2.15
+pylint~=2.11


### PR DESCRIPTION
Update dependencies and GitHub Actions according to @dependabot.

Update pre-commit hook `black`. No changes upon running pre-commit for all files.

Use only vMAJOR tag versions for GH Actions, where applicable.